### PR TITLE
Improve Digital adapter: publisher endpoint, addtl consent, syncs

### DIFF
--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -314,7 +314,7 @@ const ID_REQUEST = {
       const request = deepClone(basicRequest);
       request.imp = imps;
       request.id = getUniqueIdentifierStr();
-      setAdditionalConsent(request);
+      setAdditionalConsent(request, extendMode);
       if (transactionId) {
         deepSetValue(request, 'source.tid', transactionId);
       }

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -272,19 +272,25 @@ const ID_REQUEST = {
     const extendImps = [];
     const adServerImps = [];
 
-    function setAdditionalConsent(request) {
-      const additionalConsent = bidderRequest?.gdprConsent?.addtlConsent;
-      if (!additionalConsent) {
-        return;
-      }
-      deepSetValue(request, 'user.ext.ConsentedProvidersSettings.consented_providers', additionalConsent)
-      const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
-      if (atpIds) {
-        deepSetValue(
-          request,
-          'user.ext.consented_providers_settings.consented_providers',
-          atpIds.split('.').map(id => parseInt(id, 10))
-        );
+    function setAdditionalConsent(request, extendMode) {
+      if (bidderRequest?.gdprConsent?.addtlConsent) {
+        if (extendMode) {
+          deepSetValue(request, 'user.ext.ConsentedProvidersSettings.consented_providers', bidderRequest.gdprConsent.addtlConsent)
+        } else {
+          // Additional Consent String
+          const additionalConsent = bidderRequest.gdprConsent.addtlConsent;
+          if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
+            // Google Ad Tech Provider IDs
+            const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
+            if (atpIds) {
+              deepSetValue(
+                request,
+                'user.ext.consented_providers_settings.consented_providers',
+                atpIds.split('.').map(id => parseInt(id, 10))
+              );
+            }
+          }
+        }
       }
     }
 

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -273,22 +273,23 @@ const ID_REQUEST = {
     const adServerImps = [];
 
     function setAdditionalConsent(request, extendMode) {
-      if (bidderRequest?.gdprConsent?.addtlConsent) {
-        if (extendMode) {
-          deepSetValue(request, 'user.ext.ConsentedProvidersSettings.consented_providers', bidderRequest.gdprConsent.addtlConsent)
-        } else {
-          // Additional Consent String
-          const additionalConsent = bidderRequest.gdprConsent.addtlConsent;
-          if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
-            // Google Ad Tech Provider IDs
-            const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
-            if (atpIds) {
-              deepSetValue(
-                request,
-                'user.ext.consented_providers_settings.consented_providers',
-                atpIds.split('.').map(id => parseInt(id, 10))
-              );
-            }
+      const additionalConsent = bidderRequest?.gdprConsent?.addtlConsent;
+      if (!additionalConsent) {
+        return;
+      }
+      if (extendMode) {
+        deepSetValue(request, 'user.ext.ConsentedProvidersSettings.consented_providers', additionalConsent)
+      } else {
+        // Additional Consent String
+        if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
+          // Google Ad Tech Provider IDs
+          const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
+          if (atpIds) {
+            deepSetValue(
+              request,
+              'user.ext.consented_providers_settings.consented_providers',
+              atpIds.split('.').map(id => parseInt(id, 10))
+            );
           }
         }
       }

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -331,11 +331,15 @@ const ID_REQUEST = {
       const bidParam = bidRequest.params;
       const extendModeEnabled = this.isExtendModeEnabled(globalExtendMode, bidParam);
       const imp = this.buildImp(bidRequest, extendModeEnabled);
-      publisherId = bidParam?.publisherId;
       if (singleRequestMode) {
+        if (!publisherId) {
+          publisherId = bidParam?.publisherId;
+        } else if (publisherId && bidParam?.publisherId && publisherId !== bidParam?.publisherId) {
+          throw new Error(`All placements must have the same publisherId. Please check your 'params.publisherId'`);
+        }
         extendModeEnabled ? extendImps.push(imp) : adServerImps.push(imp);
       } else {
-        requests.push(formatRequest([imp], {transactionId: bidRequest.transactionId, publisherId}, extendModeEnabled));
+        requests.push(formatRequest([imp], {transactionId: bidRequest.transactionId, publisherId: bidParam?.publisherId}, extendModeEnabled));
       }
     });
 

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -24,8 +24,9 @@ import {loadExternalScript} from '../src/adloader.js';
 const BIDDER_CODE = 'improvedigital';
 const CREATIVE_TTL = 300;
 
-const AD_SERVER_URL = 'https://ad.360yield.com/pb';
-const BASIC_ADS_URL = 'https://ad.360yield-basic.com/pb';
+const AD_SERVER_BASE_URL = 'https://ad.360yield.com';
+const BASIC_ADS_BASE_URL = 'https://ad.360yield-basic.com';
+const PB_ENDPOINT = 'pb';
 const EXTEND_URL = 'https://pbs.360yield.com/openrtb2/auction';
 const IFRAME_SYNC_URL = 'https://hb.360yield.com/prebid-universal-creative/load-cookie.html';
 
@@ -131,20 +132,6 @@ export const spec = {
           deepSetValue(request, 'regs.ext.gdpr', Number(gdprConsent.gdprApplies));
         }
         deepSetValue(request, 'user.ext.consent', gdprConsent.consentString);
-
-        // Additional Consent String
-        const additionalConsent = deepAccess(gdprConsent, 'addtlConsent');
-        if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
-          // Google Ad Tech Provider IDs
-          const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
-          if (atpIds) {
-            deepSetValue(
-              request,
-              'user.ext.consented_providers_settings.consented_providers',
-              atpIds.split('.').map(id => parseInt(id, 10))
-            );
-          }
-        }
       }
 
       // Timeout
@@ -238,6 +225,14 @@ export const spec = {
       return [];
     }
 
+    const bidders = new Set();
+    if (this.syncStore.extendMode && serverResponses) {
+      serverResponses.forEach(response => {
+        if (!response?.body?.ext?.responsetimemillis) return;
+        Object.keys(response.body.ext.responsetimemillis).forEach(b => bidders.add(b))
+      })
+    }
+
     const syncs = [];
     if ((this.syncStore.extendMode || !syncOptions.pixelEnabled) && syncOptions.iframeEnabled) {
       const { gdprApplies, consentString } = gdprConsent || {};
@@ -248,7 +243,8 @@ export const spec = {
           (this.syncStore.extendMode ? '&pbs=1' : '') +
           (typeof gdprApplies === 'boolean' ? `&gdpr=${Number(gdprApplies)}` : '') +
           (consentString ? `&gdpr_consent=${consentString}` : '') +
-          (uspConsent ? `&us_privacy=${encodeURIComponent(uspConsent)}` : '')
+          (uspConsent ? `&us_privacy=${encodeURIComponent(uspConsent)}` : '') +
+          (bidders.size ? `&bidders=${[...bidders].join(',')}` : '')
       });
     } else if (syncOptions.pixelEnabled) {
       serverResponses.forEach(response => {
@@ -276,41 +272,86 @@ const ID_REQUEST = {
     const extendImps = [];
     const adServerImps = [];
 
-    function formatRequest(imps, transactionId, extendMode) {
+    function setAdditionalConsent(request, extendMode) {
+      if (bidderRequest?.gdprConsent?.addtlConsent) {
+        if (extendMode) {
+          deepSetValue(request, 'user.ext.ConsentedProvidersSettings.consented_providers', bidderRequest.gdprConsent.addtlConsent)
+        } else {
+          // Additional Consent String
+          const additionalConsent = bidderRequest.gdprConsent.addtlConsent;
+          if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
+            // Google Ad Tech Provider IDs
+            const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
+            if (atpIds) {
+              deepSetValue(
+                request,
+                'user.ext.consented_providers_settings.consented_providers',
+                atpIds.split('.').map(id => parseInt(id, 10))
+              );
+            }
+          }
+        }
+      }
+    }
+
+    function adServerUrl(extendMode, publisherId) {
+      if (extendMode) {
+        return EXTEND_URL;
+      }
+
+      const urlSegments = [];
+      urlSegments.push(hasPurpose1Consent(bidderRequest?.gdprConsent) ? AD_SERVER_BASE_URL : BASIC_ADS_BASE_URL)
+      if (publisherId) {
+        urlSegments.push(publisherId)
+      }
+      urlSegments.push(PB_ENDPOINT)
+
+      return urlSegments.join('/');
+    }
+
+    function formatRequest(imps, {transactionId, publisherId}, extendMode) {
       const request = deepClone(basicRequest);
       request.imp = imps;
       request.id = getUniqueIdentifierStr();
+      setAdditionalConsent(request, extendMode);
       if (transactionId) {
         deepSetValue(request, 'source.tid', transactionId);
       }
-      const adServerUrl = hasPurpose1Consent(bidderRequest?.gdprConsent) ? AD_SERVER_URL : BASIC_ADS_URL;
+
       return {
         method: 'POST',
-        url: extendMode ? EXTEND_URL : adServerUrl,
+        url: adServerUrl(extendMode, publisherId),
         data: JSON.stringify(request),
         bidderRequest
       }
     };
 
+    let publisherId = null;
     bidRequests.map((bidRequest) => {
-      const extendModeEnabled = this.isExtendModeEnabled(globalExtendMode, bidRequest.params);
+      const bidParam = bidRequest.params;
+      const extendModeEnabled = this.isExtendModeEnabled(globalExtendMode, bidParam);
       const imp = this.buildImp(bidRequest, extendModeEnabled);
+      publisherId = bidParam?.publisherId;
       if (singleRequestMode) {
         extendModeEnabled ? extendImps.push(imp) : adServerImps.push(imp);
       } else {
-        requests.push(formatRequest([imp], bidRequest.transactionId, extendModeEnabled));
+        requests.push(formatRequest([imp], {transactionId: bidRequest.transactionId, publisherId}, extendModeEnabled));
       }
     });
 
     if (!singleRequestMode) {
       return requests;
     }
+    const requestOptions = {
+      transactionId: bidderRequest.auctionId,
+      publisherId,
+    }
     // In the single request mode, split imps between those going to the ad server and those going to extend server
     if (extendImps.length) {
-      requests.push(formatRequest(extendImps, bidderRequest.auctionId, true));
+      requests.push(formatRequest(extendImps, requestOptions, true));
     }
     if (adServerImps.length) {
-      requests.push(formatRequest(adServerImps, bidderRequest.auctionId, false));
+      requests.push(formatRequest(adServerImps, requestOptions, false));
     }
 
     return requests;

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -840,10 +840,25 @@ describe('Improve Digital Adapter Tests', function () {
 
       const bidRequest2 = deepClone(simpleBidRequest)
       bidRequest2.params.publisherId = 1002;
+
+      const request1 = spec.buildRequests([bidRequest, bidRequest2], bidderRequest)[0];
+      expect(request1.url).to.equal('https://ad.360yield.com/1000/pb');
+      const request2 = spec.buildRequests([bidRequest, bidRequest2], bidderRequest)[1];
+      expect(request2.url).to.equal('https://ad.360yield.com/1002/pb');
+
+      // Enable single request mode
       getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.withArgs('improvedigital.singleRequest').returns(true);
+      try {
+        spec.buildRequests([bidRequest, bidRequest2], bidderRequest)[0];
+      } catch (e) {
+        expect(e.name).to.exist.equal('Error')
+        expect(e.message).to.exist.equal(`All placements must have the same publisherId. Please check your 'params.publisherId'`)
+      }
+
+      bidRequest2.params.publisherId = null;
       request = spec.buildRequests([bidRequest, bidRequest2], bidderRequest)[0];
-      expect(request.url).to.equal('https://ad.360yield.com/1002/pb');
+      expect(request.url).to.equal('https://ad.360yield.com/1000/pb');
 
       const consent = deepClone(gdprConsent);
       deepSetValue(consent, 'vendorData.purpose.consents.1', false);

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -817,6 +817,15 @@ describe('Improve Digital Adapter Tests', function () {
       expect(payload.regs.ext.gdpr).to.exist.and.to.equal(1);
       expect(payload.user.ext.consent).to.equal('CONSENT');
       expect(payload.user.ext.ConsentedProvidersSettings.consented_providers).to.exist.and.to.deep.equal('1~1.35.41.101');
+      expect(payload.user.ext.consented_providers_settings).to.not.exist;
+    });
+
+    it('should not add ConsentedProvidersSettings when extend mode disabled', function () {
+      const bidRequest = deepClone(simpleBidRequest);
+      const payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequestGdpr)[0].data);
+      expect(payload.regs.ext.gdpr).to.exist.and.to.equal(1);
+      expect(payload.user.ext.consent).to.equal('CONSENT');
+      expect(payload.user.ext.ConsentedProvidersSettings).to.not.exist;
       expect(payload.user.ext.consented_providers_settings.consented_providers).to.exist.and.to.deep.equal([1, 35, 41, 101]);
     });
 

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -817,15 +817,6 @@ describe('Improve Digital Adapter Tests', function () {
       expect(payload.regs.ext.gdpr).to.exist.and.to.equal(1);
       expect(payload.user.ext.consent).to.equal('CONSENT');
       expect(payload.user.ext.ConsentedProvidersSettings.consented_providers).to.exist.and.to.deep.equal('1~1.35.41.101');
-      expect(payload.user.ext.consented_providers_settings).to.not.exist;
-    });
-
-    it('should not add ConsentedProvidersSettings when extend mode disabled', function () {
-      const bidRequest = deepClone(simpleBidRequest);
-      const payload = JSON.parse(spec.buildRequests([bidRequest], bidderRequestGdpr)[0].data);
-      expect(payload.regs.ext.gdpr).to.exist.and.to.equal(1);
-      expect(payload.user.ext.consent).to.equal('CONSENT');
-      expect(payload.user.ext.ConsentedProvidersSettings).to.not.exist;
       expect(payload.user.ext.consented_providers_settings.consented_providers).to.exist.and.to.deep.equal([1, 35, 41, 101]);
     });
 
@@ -853,7 +844,7 @@ describe('Improve Digital Adapter Tests', function () {
         spec.buildRequests([bidRequest, bidRequest2], bidderRequest)[0];
       } catch (e) {
         expect(e.name).to.exist.equal('Error')
-        expect(e.message).to.exist.equal(`All placements must have the same publisherId. Please check your 'params.publisherId'`)
+        expect(e.message).to.exist.equal(`All Improve Digital placements in a single call must have the same publisherId. Please check your 'params.publisherId' or turn off the single request mode.`)
       }
 
       bidRequest2.params.publisherId = null;


### PR DESCRIPTION
Changes: 
- add bidders to sync url when extend mode enabled
- set ConsentedProvidersSettings when extend mode enabled
- dynamically generated AD_SERVER_URL when publisherId available